### PR TITLE
Split the dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,5 @@ pin-project-lite = "0.2.13"
 [features]
 default = ["smol"]
 smol = ["async-executor", "async-io"]
+async-executor = ["dep:async-executor"]
+async-io = ["dep:async-io"]

--- a/src/rt/async_executor.rs
+++ b/src/rt/async_executor.rs
@@ -3,12 +3,8 @@
 //! Integrations with `hyper::rt` for `smol` types.
 
 use async_executor::Executor;
-use hyper::rt::Sleep;
 
 use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::{Duration, Instant};
 
 /// Use an [`async-executor`] as an executor.
 #[derive(Debug, Clone)]
@@ -70,53 +66,3 @@ where
         self.get_ref().as_ref().spawn(fut).detach();
     }
 }
-
-/// Use the timer from [`async-io`].
-#[derive(Debug, Clone, Default)]
-pub struct SmolTimer {
-    _private: (),
-}
-
-impl SmolTimer {
-    /// Create a new `SmolTimer`.
-    #[inline]
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-impl hyper::rt::Timer for SmolTimer {
-    #[inline]
-    fn sleep(&self, duration: Duration) -> Pin<Box<dyn Sleep>> {
-        Box::pin(SmolSleep(async_io::Timer::after(duration)))
-    }
-
-    #[inline]
-    fn sleep_until(&self, at: Instant) -> Pin<Box<dyn Sleep>> {
-        Box::pin(SmolSleep(async_io::Timer::at(at)))
-    }
-
-    #[inline]
-    fn reset(&self, sleep: &mut Pin<Box<dyn Sleep>>, new_deadline: Instant) {
-        if let Some(mut sleep) = sleep.as_mut().downcast_mut_pin::<SmolSleep>() {
-            sleep.0.set_at(new_deadline);
-        } else {
-            *sleep = Box::pin(SmolSleep(async_io::Timer::at(new_deadline)));
-        }
-    }
-}
-
-struct SmolSleep(async_io::Timer);
-
-impl Future for SmolSleep {
-    type Output = ();
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-        match Pin::new(&mut self.0).poll(cx) {
-            Poll::Ready(_) => Poll::Ready(()),
-            Poll::Pending => Poll::Pending,
-        }
-    }
-}
-
-impl Sleep for SmolSleep {}

--- a/src/rt/async_io.rs
+++ b/src/rt/async_io.rs
@@ -1,0 +1,60 @@
+// MOT/Apache2 License
+
+//! Integrations with `hyper::rt` for `async-io` types.
+
+use hyper::rt::Sleep;
+
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use std::time::{Duration, Instant};
+
+/// Use the timer from [`async-io`].
+#[derive(Debug, Clone, Default)]
+pub struct SmolTimer {
+    _private: (),
+}
+
+impl SmolTimer {
+    /// Create a new `SmolTimer`.
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl hyper::rt::Timer for SmolTimer {
+    #[inline]
+    fn sleep(&self, duration: Duration) -> Pin<Box<dyn Sleep>> {
+        Box::pin(SmolSleep(async_io::Timer::after(duration)))
+    }
+
+    #[inline]
+    fn sleep_until(&self, at: Instant) -> Pin<Box<dyn Sleep>> {
+        Box::pin(SmolSleep(async_io::Timer::at(at)))
+    }
+
+    #[inline]
+    fn reset(&self, sleep: &mut Pin<Box<dyn Sleep>>, new_deadline: Instant) {
+        if let Some(mut sleep) = sleep.as_mut().downcast_mut_pin::<SmolSleep>() {
+            sleep.0.set_at(new_deadline);
+        } else {
+            *sleep = Box::pin(SmolSleep(async_io::Timer::at(new_deadline)));
+        }
+    }
+}
+
+struct SmolSleep(async_io::Timer);
+
+impl Future for SmolSleep {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        match Pin::new(&mut self.0).poll(cx) {
+            Poll::Ready(_) => Poll::Ready(()),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl Sleep for SmolSleep {}

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -5,7 +5,11 @@
 mod futures;
 pub use futures::FuturesIo;
 
-#[cfg(feature = "smol")]
-mod smol;
-#[cfg(feature = "smol")]
-pub use smol::{SmolExecutor, SmolTimer};
+#[cfg(feature = "async-executor")]
+mod async_executor;
+#[cfg(feature = "async-io")]
+mod async_io;
+#[cfg(feature = "async-executor")]
+pub use async_executor::SmolExecutor;
+#[cfg(feature = "async-io")]
+pub use async_io::SmolTimer;


### PR DESCRIPTION
For Bevy's new remote protocol, we need `async-io` , but may soon have our own executor implementation. It'd be ideal if this crate has higher granularity in what dependencies it pulls, so this PR splits them. `smol` as a feature is just an alias to use both of them so it shouldn't be a breaking change.